### PR TITLE
Disallow DELETE requests

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -22,6 +22,10 @@ class NeedsController < ApplicationController
     end
   end
 
+  def destroy
+    error 405, message: :method_not_allowed, errors: "Needs cannot be deleted"
+  end
+
   private
 
   def filtered_params

--- a/test/integration/deleting_needs_test.rb
+++ b/test/integration/deleting_needs_test.rb
@@ -1,0 +1,15 @@
+require_relative '../integration_test_helper'
+
+class DeletingNeedsTest < ActionDispatch::IntegrationTest
+
+  setup do
+    login_as_stub_user
+    @need = FactoryGirl.create(:need, need_id: 100001)
+  end
+
+  should "not allow deletion" do
+    delete "/needs/100001"
+    assert_equal 405, last_response.status
+    assert_equal 1, Need.count
+  end
+end


### PR DESCRIPTION
At some point we’re probably going to introduce a way to merge or remove needs. Until then, let’s explicitly refuse `DELETE` requests.
