### PR TITLE
Assign a need ID when creating, not validating

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -19,6 +19,15 @@ class Need
   field :other_evidence, type: String
   field :legislation, type: String
 
+  # This callback needs to be assigned before the `key` class method below, as
+  # otherwise Mongoid will generate a new document's key before it assigns a
+  # new need ID. Normally, ActiveModel would ensure `before_x` callbacks were
+  # invoked before `around_x` callbacks, but apparently not in this case.
+  #
+  # See: <http://edgeguides.rubyonrails.org/active_record_callbacks.html>
+  #      <http://two.mongoid.org/docs/callbacks.html>
+  before_save :assign_new_id, on: :create
+
   # Use need_id as the internal Mongo ID; see http://two.mongoid.org/docs/extras.html
   key :need_id
 
@@ -32,7 +41,6 @@ class Need
 
   validate :organisation_ids_must_exist
 
-  before_validation :assign_new_id, on: :create
   has_and_belongs_to_many :organisations
 
   private

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -153,6 +153,14 @@ class NeedTest < ActiveSupport::TestCase
       need = Need.new(@atts.merge(:organisation_ids => []))
       assert need.valid?
     end
+
+    should "not assign a need ID until creation" do
+      need = Need.new(@atts.merge(:organisation_ids => []))
+      assert need.valid?
+      assert_nil need.need_id
+      need.save!
+      refute_nil need.need_id
+    end
   end
 
   context "an existing need" do


### PR DESCRIPTION
Assigning a need ID in the post-validation hook means we can't validate
needs in bulk (for instance, during a batch import), as it'll then
assign the same ID to them all and fail when it tries to create them.

The order of the callbacks is now important, as otherwise Mongoid will
assign a new ID from its own callback before the callback fires to find
the next available need ID.
