### PR TITLE
Fix a race condition in the timestamp unit test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'shoulda-context', '1.1.5'
   gem 'simplecov', '0.7.1'
   gem 'simplecov-rcov'
+  gem 'timecop', '0.6.3'
   gem 'webmock', '1.14.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.18.1)
     tilt (1.4.1)
+    timecop (0.6.3)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -194,6 +195,7 @@ DEPENDENCIES
   shoulda-context (= 1.1.5)
   simplecov (= 0.7.1)
   simplecov-rcov
+  timecop (= 0.6.3)
   unicorn
   webmock (= 1.14.0)
   whenever (= 0.8.4)

--- a/test/unit/need_revision_test.rb
+++ b/test/unit/need_revision_test.rb
@@ -22,9 +22,11 @@ class NeedRevisionTest < ActiveSupport::TestCase
     end
 
     should "store the timestamp of the action" do
-      revision = NeedRevision.create(@atts)
+      Timecop.freeze do
+        revision = NeedRevision.create(@atts)
 
-      assert_equal Time.now.to_s, revision.created_at.to_s
+        assert_equal Time.now.to_s, revision.created_at.to_s
+      end
     end
 
     should "be invalid if the action type is not 'create' or 'update'" do


### PR DESCRIPTION
It's possible, if the test is run at just the wrong time, for the test to create a need in one second and test the timestamp in the next second, breaking the test.
