### PR TITLE
Fix the govuk_setenv app name in schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv govuk_need_api bundle exec rake :task :output'
-job_type :run_script, 'cd :path && RAILS_ENV=:environment /usr/local/bin/govuk_setenv govuk_need_api script/:task :output'
+job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv need-api bundle exec rake :task :output'
+job_type :run_script, 'cd :path && RAILS_ENV=:environment /usr/local/bin/govuk_setenv need-api script/:task :output'
 
 every 1.day, :at => '4:00am' do
   rake "organisations:import"


### PR DESCRIPTION
When calling govuk_setenv, we have to use the name of the host rather than the name of the repo.
