### PR TITLE
Use a stemmer when indexing needs

### DIFF
--- a/lib/search/index_config.rb
+++ b/lib/search/index_config.rb
@@ -7,7 +7,7 @@ module Search
     end
 
     def create_index
-      @client.create(index: @index_name)
+      @client.create(index: @index_name, body: { "settings" => index_settings })
     end
 
     def delete_index
@@ -39,6 +39,16 @@ module Search
           "include_in_all" => field.include_in_all?
         }
       end
+    end
+
+    def index_settings
+      {
+        "analysis" => {
+          "analyzer" => {
+            "default" => { "type" => "snowball" }
+          }
+        }
+      }
     end
   end
 end

--- a/test/integration/searching_needs_test.rb
+++ b/test/integration/searching_needs_test.rb
@@ -34,4 +34,22 @@ class SearchingNeedsTest < ActionDispatch::IntegrationTest
     assert_equal 1, body["results"].count
     assert_equal "apply for student finance", body["results"].first["goal"]
   end
+
+  should "match a result with a similar word" do
+    post_json "/needs", {
+       role: "student",
+       goal: "apply for student finance",
+       benefit: "I can get the money I need to go to university",
+       author: { name: "Bob", email: "bob@example.com" }
+    }.to_json
+
+    assert_equal 201, last_response.status
+
+    refresh_index
+
+    get "/needs?q=students"
+    body = JSON.parse(last_response.body)
+    assert_equal 1, body["results"].count
+    assert_equal "apply for student finance", body["results"].first["goal"]
+  end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -19,7 +19,15 @@ class ActionDispatch::IntegrationTest
     GovukNeedApi.stubs(:indexer).returns(
       Search::Indexer.new(search_client, "maslow_test", "need")
     )
-    search_client.indices.create(index: "maslow_test")
+    GovukNeedApi.stubs(:index_config).returns(
+      Search::IndexConfig.new(
+        search_client.indices,
+        "maslow_test",
+        "need",
+        Search::IndexableNeed
+      )
+    )
+    GovukNeedApi.index_config.create_index
 
     # Wait until the new index reports it's started up
     timeout(2) do

--- a/test/unit/search/index_config_test.rb
+++ b/test/unit/search/index_config_test.rb
@@ -2,8 +2,18 @@ require "test_helper"
 
 class IndexConfigTest < ActiveSupport::TestCase
   should "create an index" do
-    mock_client = mock("index client") do
-      expects(:create).with(index: "maslow-test")
+    mock_client = mock("index client")
+    mock_client.expects(:create).with(has_entry(index: "maslow-test"))
+
+    Search::IndexConfig.new(mock_client, "maslow-test", nil, nil).create_index
+  end
+
+  should "pass in analysis settings" do
+    mock_client = mock("index client")
+    mock_client.expects(:create).with do |params|
+      params[:body] &&
+      params[:body]["settings"] &&
+      params[:body]["settings"]["analysis"]
     end
 
     Search::IndexConfig.new(mock_client, "maslow-test", nil, nil).create_index


### PR DESCRIPTION
This lets us match "student" when someone searches for "students", for example, or "drive" when someone searches for "driving".

Note that this pull request is against the `search-needs` branch, so will affect #23.
