### PR TITLE
Disallow organisation IDs for needs which apply to all orgs

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -48,6 +48,7 @@ class Need
   validates_numericality_of :yearly_searches, :greater_than_or_equal_to => 0, :allow_nil => true, :only_integer => true
 
   validate :organisation_ids_must_exist
+  validate :no_organisations_if_applies_to_all
 
   has_and_belongs_to_many :organisations
   has_many :revisions, class_name: "NeedRevision"
@@ -71,6 +72,15 @@ class Need
     org_ids = (organisation_ids || []).uniq
     if Organisation.any_in(_id: org_ids).count < org_ids.size
       errors.add(:organisation_ids, "must exist")
+    end
+  end
+
+  def no_organisations_if_applies_to_all
+    if applies_to_all_organisations && organisation_ids.present?
+      errors.add(
+        :organisation_ids,
+        "cannot exist if applies_to_all_organisations is set"
+      )
     end
   end
 

--- a/test/integration/creating_needs_test.rb
+++ b/test/integration/creating_needs_test.rb
@@ -32,7 +32,7 @@ class CreatingNeedsTest < ActionDispatch::IntegrationTest
       "yearly_searches" => 2000,
       "other_evidence" => "Other evidence",
       "legislation" => "link#1\nlink#2",
-      "applies_to_all_organisations" => true,
+      "applies_to_all_organisations" => false,
       "author" => {
         "name" => "Winston Smith-Churchill",
         "email" => "winston@alphagov.co.uk"
@@ -49,7 +49,7 @@ class CreatingNeedsTest < ActionDispatch::IntegrationTest
     assert_equal "find out the minimum wage", body["goal"]
     assert_equal "I can work out if I am being paid the correct amount", body["benefit"]
     assert_equal ["department-for-work-and-pensions", "hm-treasury"], body["organisation_ids"]
-    assert_equal true, body["applies_to_all_organisations"]
+    assert_equal false, body["applies_to_all_organisations"]
 
     assert_equal ["legislation"], body["justifications"]
     assert_equal "Noticed by many citizens", body["impact"]

--- a/test/unit/need_test.rb
+++ b/test/unit/need_test.rb
@@ -23,7 +23,7 @@ class NeedTest < ActiveSupport::TestCase
         yearly_searches: 2000,
         other_evidence: "Other evidence",
         legislation: "link#1\nlink#2",
-        applies_to_all_organisations: true
+        applies_to_all_organisations: false
       }
     end
 
@@ -48,7 +48,7 @@ class NeedTest < ActiveSupport::TestCase
       assert_equal 2000, need.yearly_searches
       assert_equal "Other evidence", need.other_evidence
       assert_equal "link#1\nlink#2", need.legislation
-      assert_equal true, need.applies_to_all_organisations
+      assert_equal false, need.applies_to_all_organisations
     end
 
     context "assigning need ids" do
@@ -167,6 +167,31 @@ class NeedTest < ActiveSupport::TestCase
       need.reload
 
       assert_equal false, need.applies_to_all_organisations
+    end
+
+    should "disallow applies_to_all_organisations with explicit organisations" do
+      need_atts = @atts.merge(
+        applies_to_all_organisations: true,
+        organisation_ids: ["cabinet-office"]
+      )
+      need = Need.new(need_atts)
+      refute need.valid?
+    end
+
+    should "allow applies_to_all_organisations with no organisations" do
+      need_atts = @atts.merge(
+        applies_to_all_organisations: true,
+        organisation_ids: []
+      )
+      need = Need.new(need_atts)
+      assert need.valid?
+    end
+
+    should "allow applies_to_all_organisations with organisation IDs not set" do
+      need_atts = @atts.merge(applies_to_all_organisations: true)
+        .except(:organisation_ids)
+      need = Need.new(need_atts)
+      assert need.valid?
     end
 
     context "creating revisions" do


### PR DESCRIPTION
Intended for further discussion on the back of #30.

Since the intention is that the `applies_to_all_organisations` flag, if set, overrides the `organisation_ids` field, it makes sense to be explicit and not allow any IDs to be set.

We're only expecting to instantiate a small number of these needs, and not allow extra ones to be set in Maslow itself, so we shouldn't need to worry about someone trying to set this flag on a need that already has organisations set.
