### PR TITLE
Search on the need_id field in addition to _all

### DIFF
--- a/lib/search/searcher.rb
+++ b/lib/search/searcher.rb
@@ -9,7 +9,18 @@ module Search
       results = @client.search(
         index: @index_name,
         type: @type,
-        body: { "query" => { "match" => { "_all" => query } } }
+        body: {
+          "query" => {
+            "multi_match" => {
+              "fields" => [ "_all", "need_id" ],
+              "query" => query,
+
+              # The 'lenient' flag prevents an exception being raised when a string
+              # is searched for on the numeric need_id field.
+              "lenient" => true
+            }
+          }
+        }
       )
 
       results["hits"]["hits"].map { |r| Search::NeedSearchResult.new(r["_source"]) }

--- a/test/integration/searching_needs_test.rb
+++ b/test/integration/searching_needs_test.rb
@@ -56,4 +56,24 @@ class SearchingNeedsTest < ActionDispatch::IntegrationTest
     assert_equal 1, body["results"].count
     assert_equal "apply for student finance", body["results"].first["goal"]
   end
+
+  should "match a result on the need ID" do
+    post_json "/needs", {
+       role: "student",
+       goal: "apply for student finance",
+       benefit: "I can get the money I need to go to university",
+       author: { name: "Bob", email: "bob@example.com" }
+    }.to_json
+
+    assert_equal 201, last_response.status
+    submitted_need = JSON.parse(last_response.body)
+
+    refresh_index
+
+    get "/needs?q=#{submitted_need["id"]}"
+
+    body = JSON.parse(last_response.body)
+    assert_equal 1, body["results"].count
+    assert_equal "apply for student finance", body["results"].first["goal"]
+  end
 end

--- a/test/unit/search/searcher_test.rb
+++ b/test/unit/search/searcher_test.rb
@@ -3,7 +3,15 @@ require "test_helper"
 class SearcherTest < ActiveSupport::TestCase
 
   def body_for_query(query)
-    { "query" => { "match" => { "_all" => query } } }
+    {
+      "query" => {
+        "multi_match" => {
+          "fields" => ["_all", "need_id"],
+          "query" => query,
+          "lenient" => true
+        }
+      }
+    }
   end
 
   should "do a search" do


### PR DESCRIPTION
This changes the search query to include the need_id field. To do this, the query has been changed to a 'multi_match' query, which now performs an 'or' search across the "_all" and "need_id" fields.
