### PR TITLE
Raise the limit on search results

### DIFF
--- a/lib/search/searcher.rb
+++ b/lib/search/searcher.rb
@@ -19,7 +19,8 @@ module Search
               # is searched for on the numeric need_id field.
               "lenient" => true
             }
-          }
+          },
+          "size" => 50,
         }
       )
 

--- a/test/unit/search/searcher_test.rb
+++ b/test/unit/search/searcher_test.rb
@@ -64,6 +64,16 @@ class SearcherTest < ActiveSupport::TestCase
     Search::Searcher.new(client, "foo", "bang").search("baz")
   end
 
+  should "ask for 50 results" do
+    client = mock("client")
+    client.expects(:search).with { |search_params|
+      query_params = search_params[:body]["query"].values.first
+      query_params["query"] == "baz"
+    }.returns(single_result_response)
+
+    Search::Searcher.new(client, "foo", "bang").search("baz")
+  end
+
   should "parse out the search results" do
     client = mock("client")
     client.expects(:search).returns(single_result_response)


### PR DESCRIPTION
By default, elasticsearch returns 10 results, which isn't enough. Returning 50 is consistent with the list pagination.
