### PR TITLE
Fix pagination of needs when filtering.

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -21,7 +21,7 @@ class NeedsController < ApplicationController
 
     @needs = scope.page(params[:page])
 
-    presenter = NeedResultSetPresenter.new(@needs, view_context)
+    presenter = NeedResultSetPresenter.new(@needs, view_context, :scope_params => params.slice(:organisation_id, :ids))
     response.headers["Link"] = LinkHeader.new(presenter.links).to_s
 
     set_expiry 0

--- a/app/presenters/need_result_set_presenter.rb
+++ b/app/presenters/need_result_set_presenter.rb
@@ -1,9 +1,10 @@
 require 'link_header'
 
 class NeedResultSetPresenter
-  def initialize(needs, view_context)
+  def initialize(needs, view_context, options = {})
     @needs = needs
     @view_context = view_context
+    @scope_params = options[:scope_params] || {}
   end
 
   def as_json
@@ -37,20 +38,20 @@ class NeedResultSetPresenter
 
       unless @needs.first_page?
         links << LinkHeader::Link.new(
-          @view_context.needs_url(page: @needs.current_page-1),
+          @view_context.needs_url(@scope_params.merge(page: @needs.current_page-1)),
           [["rel", "previous"]]
         )
       end
 
       unless @needs.last_page?
         links << LinkHeader::Link.new(
-          @view_context.needs_url(page: @needs.current_page+1),
+          @view_context.needs_url(@scope_params.merge(page: @needs.current_page+1)),
           [["rel", "next"]]
         )
       end
 
       links << LinkHeader::Link.new(
-        @view_context.needs_url(page: @needs.current_page),
+        @view_context.needs_url(@scope_params.merge(page: @needs.current_page)),
         [["rel", "self"]]
       )
     }

--- a/test/unit/presenters/need_result_set_presenter_test.rb
+++ b/test/unit/presenters/need_result_set_presenter_test.rb
@@ -181,6 +181,34 @@ class NeedResultSetPresenterTest < ActiveSupport::TestCase
       assert_equal "self", links[2].attrs["rel"]
     end
 
+    should "include given scope params in the links" do
+      @needs.current_page = 2
+
+      @view_context.expects(:needs_url)
+                      .with(:page => 1, :foo => "bar")
+                      .returns("scoped url to page 1")
+      @view_context.expects(:needs_url)
+                      .with(:page => 2, :foo => "bar")
+                      .returns("scoped url to page 2")
+      @view_context.expects(:needs_url)
+                      .with(:page => 3, :foo => "bar")
+                      .returns("scoped url to page 3")
+
+      links = NeedResultSetPresenter.new(@needs, @view_context, :scope_params => {:foo => "bar"}).links
+
+      assert_equal 3, links.size
+      assert links.all? {|l| l.is_a?(LinkHeader::Link) }
+
+      assert_equal "scoped url to page 1", links[0].href
+      assert_equal "previous", links[0].attrs["rel"]
+
+      assert_equal "scoped url to page 3", links[1].href
+      assert_equal "next", links[1].attrs["rel"]
+
+      assert_equal "scoped url to page 2", links[2].href
+      assert_equal "self", links[2].attrs["rel"]
+    end
+
     should "not return links to the previous page when on the first page" do
       @needs.current_page = 1
       @needs.stubs(:first_page?).returns(true)


### PR DESCRIPTION
This wasn't including the scope params in the pagination links.  This
meant that when following these links, clients ended up fetching pages 2
onwards of all the needs as opposed to the filtered set they'd
originally requested.

Fixes pivotal: https://www.pivotaltracker.com/story/show/68087676
