### PR TITLE
Ensure correct scope is used when ids is empty

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -170,7 +170,7 @@ class NeedsController < ApplicationController
   end
 
   def need_ids
-    if params[:ids].present?
+    if params[:ids]
       params[:ids].split(',').map(&:strip).map(&:to_i)
     end
   end

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -76,6 +76,25 @@ class NeedsControllerTest < ActionController::TestCase
     end
   end
 
+  context "GET index with empty need ids" do
+    setup do
+      @needs = FactoryGirl.create_list(:need, 3)
+      get :index, ids: ''
+    end
+
+    should "return a success status" do
+      assert_response :success
+
+      body = JSON.parse(response.body)
+      assert_equal "ok", body["_response_info"]["status"]
+    end
+
+    should "return a response containing an empty set" do
+      body = JSON.parse(response.body)
+      assert_equal 0, body["results"].size
+    end
+  end
+
   context "GET index with search parameter" do
     setup do
       @results = [


### PR DESCRIPTION
When an empty set of ids was specified, the default index scope was being invoked, returning all needs instead of none as it should have been. To get Mongoid to do the right thing, we pass in an empty array when the id param is blank.
