### PR TITLE
Include met when criteria in need search result

### DIFF
--- a/app/presenters/basic_need_presenter.rb
+++ b/app/presenters/basic_need_presenter.rb
@@ -17,6 +17,7 @@ class BasicNeedPresenter
       role: @need.role,
       goal: @need.goal,
       benefit: @need.benefit,
+      met_when: @need.met_when,
       organisation_ids: @need.organisation_ids,
       organisations: organisations,
       applies_to_all_organisations: @need.applies_to_all_organisations,

--- a/test/unit/presenters/basic_need_presenter_test.rb
+++ b/test/unit/presenters/basic_need_presenter_test.rb
@@ -9,6 +9,7 @@ class BasicNeedPresenterTest < ActiveSupport::TestCase
       role: "business owner",
       goal: "find out the VAT rate",
       benefit: "I can charge my customers the correct amount",
+      met_when: [ "the user sees the current vat rate", "the api user can access the current vat rate" ],
       organisation_ids: [ "ministry-of-testing" ],
       organisations: [
         OpenStruct.new(id: "ministry-of-testing", name: "Ministry of Testing", slug: "ministry-of-testing")
@@ -30,6 +31,9 @@ class BasicNeedPresenterTest < ActiveSupport::TestCase
     assert_equal "business owner", response[:role]
     assert_equal "find out the VAT rate", response[:goal]
     assert_equal "I can charge my customers the correct amount", response[:benefit]
+
+    assert_equal [ "the user sees the current vat rate",
+      "the api user can access the current vat rate" ], response[:met_when]
 
     assert_equal ["ministry-of-testing"], response[:organisation_ids]
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5644

we're seeing time-outs while exporting even a
small set of needs as CSV. this is caused due
to Maslow calling Need API once for every need
row in the CSV only to fetch met when criteria.

given that met when criteria are an essential
piece of information without which editors can't
process the information they got in the CSV, we
should include these in the basic need result
set. this will serve all information needed by
Maslow to prepare a CSV in one API call.
