### PR TITLE
Fix to the CSV needs importer

### DIFF
--- a/lib/needs_importer.rb
+++ b/lib/needs_importer.rb
@@ -45,7 +45,7 @@ class NeedsImporter
       "goal" => row['I need to...'],
       "benefit" => row['so that...'],
     }
-    add(need, "organisation_ids", [row['Organisation Id']])
+    add(need, "organisation_ids", [row['Organisation Id']].compact)
     add(need, "met_when", met_when(row))
     add(need, "justifications", justifications(row))
     add(need, "impact", impact(row))

--- a/test/unit/needs_importer_test.rb
+++ b/test/unit/needs_importer_test.rb
@@ -1,0 +1,38 @@
+require_relative '../test_helper'
+
+require 'fileutils'
+require 'csv'
+require 'needs_importer'
+
+class NeedsImporterTest < ActiveSupport::TestCase
+
+  setup do
+    FileUtils.mkdir_p 'tmp'
+    CSV.open('tmp/test-needs.csv', "wb") do |csv|
+      csv << [ 'As a...', 'I need to...', 'so that...' ]
+      csv << [ 'user', 'pay my car tax', 'avoid paying a fine' ]
+      csv << [ 'jobseeker', 'log into Jobsearch', "prove that I'm looking for work" ]
+    end
+  end
+
+  teardown do
+    FileUtils.rm 'tmp/test-needs.csv'
+  end
+
+  should "import bare-minimum needs" do
+    NeedsImporter.new('tmp/test-needs.csv').run
+
+    assert_equal 2, Need.count
+
+    assert Need.where(
+      role: "user",
+      goal: "pay my car tax",
+      benefit: "avoid paying a fine",
+    ).first
+    assert Need.where(
+      role: "jobseeker",
+      goal: "log into Jobsearch",
+      benefit: "prove that I'm looking for work",
+    ).first
+  end
+end


### PR DESCRIPTION
This fixes the CSV importer so it can import needs that
didn't have an organisation column (even if setting no org on the need
is valid). This also introduces a rudimentary test for the importer.
