### PR TITLE
Include duplicate_of in need search results

### DIFF
--- a/lib/search/indexable_need.rb
+++ b/lib/search/indexable_need.rb
@@ -24,6 +24,7 @@ module Search
         Field.new(:legislation, "string", false, false),
         Field.new(:other_evidence, "string", true, true),
         Field.new(:in_scope, "boolean", false, false),
+        Field.new(:duplicate_of, "string", false, false),
       ]
     end
 

--- a/test/unit/search/indexable_need_test.rb
+++ b/test/unit/search/indexable_need_test.rb
@@ -20,7 +20,8 @@ module Search
         yearly_need_views: 1000,
         yearly_searches: 1000,
         currently_met: false,
-        in_scope: false
+        in_scope: false,
+        duplicate_of: 654321
       )
       @indexable_need = IndexableNeed.new(need)
     end
@@ -39,6 +40,7 @@ module Search
       assert_equal ["org-1"], presented_need[:organisation_ids]
       assert_equal true, presented_need[:applies_to_all_organisations]
       assert_equal false, presented_need[:in_scope]
+      assert_equal 654321, presented_need[:duplicate_of]
       assert_equal ["Criteria 1", "Criteria 2"], presented_need[:met_when]
       assert_equal ["Legislation 1", "Legislation 2"], presented_need[:legislation]
       assert_equal ["Evidence 1", "Evidence 2"], presented_need[:other_evidence]


### PR DESCRIPTION
Without the `duplicate_of` field Maslow’s search results table misrepresents duplicate needs by showing an empty “Decision made” column.

Fixes https://www.pivotaltracker.com/story/show/78193142

Before:
![screen shot 2014-10-03 at 14 17 19](https://cloud.githubusercontent.com/assets/319055/4506281/08190a0c-4b01-11e4-9654-f8a0ea378592.png)

After:
![screen shot 2014-10-03 at 14 17 12](https://cloud.githubusercontent.com/assets/319055/4506285/0e92fbb8-4b01-11e4-912f-a902af318c19.png)
