### PR TITLE
Update organisations once per hour

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,6 +2,6 @@ set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
 job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv need-api bundle exec rake :task :output'
 job_type :run_script, 'cd :path && RAILS_ENV=:environment /usr/local/bin/govuk_setenv need-api script/:task :output'
 
-every 1.day, :at => '4:00am' do
+every :hour do
   rake "organisations:import"
 end


### PR DESCRIPTION
In combination with https://github.com/alphagov/maslow/pull/120 This should mean that the organisations list in Maslow is no more than 2 hours out of date.
