### PR TITLE
Speed up the DistributedLock test

### DIFF
--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -2,14 +2,18 @@ require 'redis'
 require 'redis-lock'
 
 class DistributedLock
-  LIFETIME = (5 * 60) # seconds
+  DEFAULTS = {
+    life: (5 * 60), # lifetime (in seconds)
+    acquire: 10, # acquisition timeout (in seconds). This is how long a 2nd lock waits if there's a 1st one already
+  }
 
-  def initialize(lock_name)
+  def initialize(lock_name, options = {})
     @lock_name = lock_name
+    @options = DEFAULTS.merge(options)
   end
 
   def lock
-    redis.lock("need-api:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
+    redis.lock("need-api:#{Rails.env}:#{@lock_name}", @options) do
       Rails.logger.debug('Successfully got a lock. Running...')
       yield
     end

--- a/test/unit/distributed_lock_test.rb
+++ b/test/unit/distributed_lock_test.rb
@@ -8,7 +8,7 @@ class DistributedLockTest < ActiveSupport::TestCase
 
       DistributedLock.new('testing').lock do
         outer_block_executed = true
-        DistributedLock.new('testing').lock do
+        DistributedLock.new('testing', acquire: 0.5).lock do
           inner_block_executed = true
         end
       end


### PR DESCRIPTION
https://github.com/alphagov/govuk_need_api/pull/68 introduced the DistributedLock
and related tests. This change speeds up the tests by making the lock acquisition timeout
configurable and much shorter (which shaves 9.5 seconds off the unit test run).
