### PR TITLE
Switch BasicNeedPresenter#{present => as_json}

### DIFF
--- a/app/presenters/basic_need_presenter.rb
+++ b/app/presenters/basic_need_presenter.rb
@@ -5,14 +5,6 @@ class BasicNeedPresenter
 
   def as_json
     {
-      _response_info: {
-        status: "ok"
-      }
-    }.merge(present)
-  end
-
-  def present
-    {
       id: @need.need_id,
       role: @need.role,
       goal: @need.goal,

--- a/app/presenters/need_result_set_presenter.rb
+++ b/app/presenters/need_result_set_presenter.rb
@@ -29,7 +29,7 @@ class NeedResultSetPresenter
   private
   def results
     @needs.map {|need|
-      BasicNeedPresenter.new(need).present
+      BasicNeedPresenter.new(need).as_json
     }
   end
 

--- a/app/presenters/need_search_result_set_presenter.rb
+++ b/app/presenters/need_search_result_set_presenter.rb
@@ -23,7 +23,7 @@ class NeedSearchResultSetPresenter
   private
   def results
     @needs.map {|need|
-      BasicNeedPresenter.new(need).present
+      BasicNeedPresenter.new(need).as_json
     }
   end
 

--- a/test/unit/presenters/basic_need_presenter_test.rb
+++ b/test/unit/presenters/basic_need_presenter_test.rb
@@ -25,7 +25,6 @@ class BasicNeedPresenterTest < ActiveSupport::TestCase
   should "return a need as json" do
     response = @presenter.as_json
 
-    assert_equal "ok", response[:_response_info][:status]
     assert_equal 123456, response[:id]
 
     assert_equal "business owner", response[:role]


### PR DESCRIPTION
The `as_json` method is used in all other classes. Furthermore, the `_response_info` isn't actually
necessary in any controller, so it's dropped.
