### PR TITLE
Remove the deprecated 'out of scope' need status

### DIFF
--- a/app/models/need_status.rb
+++ b/app/models/need_status.rb
@@ -14,7 +14,7 @@ class NeedStatus
   field :additional_comments, type: String
   field :validation_conditions, type: String
 
-  validates :description, presence: true, inclusion: { in: [PROPOSED, "out of scope", NOT_VALID, VALID, VALID_WITH_CONDITIONS] }
+  validates :description, presence: true, inclusion: { in: [PROPOSED, NOT_VALID, VALID, VALID_WITH_CONDITIONS] }
 
   validates :reasons, presence: true, if: Proc.new { |s| s.description == NOT_VALID }
   validates :validation_conditions, presence: true, if: Proc.new { |s| s.description == VALID_WITH_CONDITIONS }

--- a/test/unit/need_status_test.rb
+++ b/test/unit/need_status_test.rb
@@ -2,7 +2,7 @@ require_relative '../test_helper'
 
 class NeedStatusTest < ActiveSupport::TestCase
   should validate_presence_of(:description)
-  should validate_inclusion_of(:description).in_array([NeedStatus::PROPOSED, "out of scope", NeedStatus::NOT_VALID, NeedStatus::VALID, NeedStatus::VALID_WITH_CONDITIONS])
+  should validate_inclusion_of(:description).in_array([NeedStatus::PROPOSED, NeedStatus::NOT_VALID, NeedStatus::VALID, NeedStatus::VALID_WITH_CONDITIONS])
 
   should allow_value("abc").for(:additional_comments)
 


### PR DESCRIPTION
Maslow no longer supports this status and the needs in the database
have all been migrated away from it, so it can be safely removed.
