### PR TITLE
Remove deprecated 'reason' field on need status

### DIFF
--- a/app/models/need_status.rb
+++ b/app/models/need_status.rb
@@ -9,7 +9,6 @@ class NeedStatus
   embedded_in :need
 
   field :description, type: String
-  field :reason, type: String # this field is deprecated and will be removed soon
   field :reasons, type: Array
   field :additional_comments, type: String
   field :validation_conditions, type: String

--- a/db/migrate/20141204152046_remove_need_status_reason_field.rb
+++ b/db/migrate/20141204152046_remove_need_status_reason_field.rb
@@ -1,0 +1,11 @@
+class RemoveNeedStatusReasonField < Mongoid::Migration
+  def self.up
+    Need.all.each do |need|
+      need.status.unset(:reason)
+    end
+  end
+
+  def self.down
+    Rails.logger.warn("Cannot reinstate the status reason field")
+  end
+end


### PR DESCRIPTION
This field is no longer being used for anything.
