### PR TITLE
Support search and organisation filtering together

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -8,7 +8,7 @@ class NeedsController < ApplicationController
     scope = Need
 
     if params["q"].present?
-      search(params["q"]) and return
+      search(params["q"], params["organisation_id"]) and return
     end
 
     if org = params["organisation_id"] and org.present?
@@ -142,10 +142,10 @@ class NeedsController < ApplicationController
     end
   end
 
-  def search(query)
+  def search(query, organisation_id)
     # TODO: reject page parameter
 
-    results = GovukNeedApi.searcher.search(query)
+    results = GovukNeedApi.searcher.search(query, organisation_id)
     set_expiry 0
 
     presenter = NeedSearchResultSetPresenter.new(results, query, view_context)

--- a/lib/search/searcher.rb
+++ b/lib/search/searcher.rb
@@ -5,26 +5,47 @@ module Search
       @index_name, @type = index_name, type
     end
 
-    def search(query)
+    def search(querystring, organisation_id=nil)
       results = @client.search(
         index: @index_name,
         type: @type,
         body: {
-          "query" => {
-            "multi_match" => {
-              "fields" => [ "_all", "need_id" ],
-              "query" => query,
-
-              # The 'lenient' flag prevents an exception being raised when a string
-              # is searched for on the numeric need_id field.
-              "lenient" => true
-            }
-          },
+          "query" => build_query(querystring, organisation_id),
           "size" => 50,
         }
       )
 
       results["hits"]["hits"].map { |r| Search::NeedSearchResult.new(r["_source"]) }
+    end
+
+    def build_query(querystring, organisation_id)
+      if organisation_id
+        {
+          "filtered" => {
+            "filter" => {
+              "term" => {
+                "organisation_ids" => organisation_id
+              }
+            },
+            "query" => querystring_query(querystring)
+          }
+        }
+      else
+        querystring_query(querystring)
+      end
+    end
+
+    def querystring_query(querystring)
+      {
+        "multi_match" => {
+          "fields" => [ "_all", "need_id" ],
+          "query" => querystring,
+
+          # The 'lenient' flag prevents an exception being raised when a string
+          # is searched for on the numeric need_id field.
+          "lenient" => true
+        }
+      }
     end
   end
 end

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -107,7 +107,7 @@ class NeedsControllerTest < ActionController::TestCase
         )
       ]
       mock_searcher = mock("searcher")
-      mock_searcher.expects(:search).with("fish").returns(@results)
+      mock_searcher.expects(:search).with("fish", nil).returns(@results)
       GovukNeedApi.stubs(:searcher).returns(mock_searcher)
     end
 
@@ -170,6 +170,49 @@ class NeedsControllerTest < ActionController::TestCase
     should "set cache-control headers to zero" do
       get :index
 
+      assert_equal "max-age=0, public", response.headers["Cache-Control"]
+    end
+  end
+
+  context "GET index with search AND organisation_id parameters" do
+    setup do
+      @needs = [
+        @matching_co_need    = create(:need, organisation_ids: ["cabinet-office"], role: "a cheeseboard"),
+        @nonmatching_co_need = create(:need, organisation_ids: ["cabinet-office"], role: "a chalkboard"),
+        @dft_need            = create(:need, organisation_ids: ["department-for-transport"], role: "a cheeseknife")
+      ]
+
+      @results = [
+        Search::NeedSearchResult.new(
+          "need_id" => 100001,
+          "role" => @matching_co_need.role,
+          "goal" => @matching_co_need.goal,
+          "benefit" => @matching_co_need.benefit,
+          "organisation_ids" => @matching_co_need.organisation_ids
+        )
+      ]
+      mock_searcher = mock("searcher")
+      mock_searcher.expects(:search).with("cheese", "cabinet-office").returns(@results)
+      GovukNeedApi.stubs(:searcher).returns(mock_searcher)
+
+      get :index, organisation_id: 'cabinet-office', q: 'cheese'
+    end
+
+    should "return a success status" do
+      assert_response :success
+
+      body = JSON.parse(response.body)
+      assert_equal "ok", body["_response_info"]["status"]
+    end
+
+    should "return only the needs related to that organisation" do
+      body = JSON.parse(response.body)
+
+      assert_equal 1, body["results"].size
+      assert_equal @matching_co_need.need_id, body["results"][0]["id"]
+    end
+
+    should "set cache-control headers to zero" do
       assert_equal "max-age=0, public", response.headers["Cache-Control"]
     end
   end


### PR DESCRIPTION
This will enable us to offer the same functionality in Maslow, the lack of which drives me crazy when using it.

At the moment, govuk_need_api silently ignores the organisation_id param if
supplied with the q search param.
