### PR TITLE
Paginate search results

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -31,7 +31,8 @@ class Need
 
   default_scope order_by([:_id, :desc])
 
-  paginates_per 50
+  PAGE_SIZE = 50
+  paginates_per PAGE_SIZE
 
   # This callback needs to be assigned before the `key` class method below, as
   # otherwise Mongoid will generate a new document's key before it assigns a

--- a/app/presenters/need_result_set_presenter.rb
+++ b/app/presenters/need_result_set_presenter.rb
@@ -13,7 +13,7 @@ class NeedResultSetPresenter
         status: "ok",
         links: links.map {|l| { "href" => l.href }.merge(l.attrs) }
       },
-      total: @needs.count,
+      total: @needs.total_count,
       current_page: @needs.current_page,
       pages: @needs.total_pages,
       start_index: start_index,

--- a/lib/search/need_search_result_set.rb
+++ b/lib/search/need_search_result_set.rb
@@ -1,0 +1,10 @@
+module Search
+  class NeedSearchResultSet
+    attr_reader :results, :total_count
+
+    def initialize(results, total_count)
+      @results = results
+      @total_count = total_count
+    end
+  end
+end

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -107,7 +107,8 @@ class NeedsControllerTest < ActionController::TestCase
         )
       ]
       mock_searcher = mock("searcher")
-      mock_searcher.expects(:search).with("fish", nil).returns(@results)
+      mock_searcher.expects(:search).with("fish", {})
+                   .returns(Search::NeedSearchResultSet.new(@results, 1))
       GovukNeedApi.stubs(:searcher).returns(mock_searcher)
     end
 
@@ -192,7 +193,8 @@ class NeedsControllerTest < ActionController::TestCase
         )
       ]
       mock_searcher = mock("searcher")
-      mock_searcher.expects(:search).with("cheese", "cabinet-office").returns(@results)
+      mock_searcher.expects(:search).with("cheese", 'organisation_id' => "cabinet-office")
+                   .returns(::Search::NeedSearchResultSet.new(@results, 1))
       GovukNeedApi.stubs(:searcher).returns(mock_searcher)
 
       get :index, organisation_id: 'cabinet-office', q: 'cheese'

--- a/test/integration/searching_needs_test.rb
+++ b/test/integration/searching_needs_test.rb
@@ -75,4 +75,37 @@ class SearchingNeedsTest < ActionDispatch::IntegrationTest
     assert_equal 1, body["results"].count
     assert_equal "apply for student finance", body["results"].first["goal"]
   end
+
+  should "paginate the matching needs correctly" do
+    52.times do |n|
+      post_json "/needs", {
+         role: "monkey #{n}",
+         goal: "apply for monkey finance",
+         benefit: "I can get the money I need to go to monkeyversity",
+         author: { name: "Bob", email: "bob@example.com" },
+         applies_to_all_organisations: true,
+      }.to_json
+
+      assert_equal 201, last_response.status, last_response.body
+    end
+
+    # Elasticsearch needs a little time to index the search results in the background
+    sleep 3
+
+    get "/needs?q=monkeys"
+
+    assert_equal 200, last_response.status
+    body = JSON.parse(last_response.body)
+    assert_equal 50, body["results"].size
+    assert_equal 52, body["total"]
+
+    assert last_response.headers.has_key?("Link")
+    link_header = LinkHeader.parse(last_response.headers["Link"])
+    assert_equal "http://example.org/needs?page=2&q=monkeys", link_header.find_link(["rel", "next"]).href
+
+    get "/needs?q=monkeys&page=2"
+    assert_equal 200, last_response.status
+    body = JSON.parse(last_response.body)
+    assert_equal 2, body["results"].size
+  end
 end

--- a/test/unit/presenters/need_result_set_presenter_test.rb
+++ b/test/unit/presenters/need_result_set_presenter_test.rb
@@ -244,7 +244,7 @@ class NeedResultSetPresenterTest < ActiveSupport::TestCase
   end
 
   should "include the total number of needs" do
-    @needs.expects(:count).returns(50)
+    @needs.expects(:total_count).returns(50)
 
     response = NeedResultSetPresenter.new(@needs, @view_context).as_json
 

--- a/test/unit/search/searcher_test.rb
+++ b/test/unit/search/searcher_test.rb
@@ -64,21 +64,31 @@ class SearcherTest < ActiveSupport::TestCase
     Search::Searcher.new(client, "foo", "bang").search("baz")
   end
 
-  should "ask for 50 results" do
+  should "ask for the first 50 results" do
     client = mock("client")
     client.expects(:search).with { |search_params|
-      query_params = search_params[:body]["query"].values.first
-      query_params["query"] == "baz"
+      50 == search_params[:body]["size"] &&
+      0 == search_params[:body]["from"]
     }.returns(single_result_response)
 
     Search::Searcher.new(client, "foo", "bang").search("baz")
+  end
+
+  should "ask for the next 50 results" do
+    client = mock("client")
+    client.expects(:search).with { |search_params|
+      50 == search_params[:body]["size"] &&
+      50 == search_params[:body]["from"]
+    }.returns(single_result_response)
+
+    Search::Searcher.new(client, "foo", "bang").search("baz", page: 2)
   end
 
   should "parse out the search results" do
     client = mock("client")
     client.expects(:search).returns(single_result_response)
 
-    results = Search::Searcher.new(client, "foo", "bang").search("cheese")
-    assert_equal ["fishmonger"], results.map(&:role)
+    result_set = Search::Searcher.new(client, "foo", "bang").search("cheese")
+    assert_equal ["fishmonger"], result_set.results.map(&:role)
   end
 end


### PR DESCRIPTION
Make search results paginatable. This also shortens and simplifies the code.

Previously it was silently ignoring pagination params if supplied. Search results after the first 50 couldn't be obtained.

Had to switch from `count` to Kaminari's `total_count` method because, while
either works with a Mongoid result set, `count` returned the size of the array
when called on an array.

This change will automatically give us paginating search results in Maslow.