### PR TITLE
Add Redis to the dependency list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Need API is a JSON read and write API for information about user needs on GO
 - Bundler
 - MongoDB
 - Elasticsearch (running on port 9200)
+- Redis (running on port 6379)
 
 The Need API is not dependent on any other GOV.UK appliations in order to run.
 


### PR DESCRIPTION
Hat-tip to Dan Blundell for pointing this out.
http://danblundell.com/2015/02/maslow-how-to-spin-up-the-gov-dot-uk-needs-api/