### PR TITLE
Replace exception_notification with airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.17'
 gem 'mongoid', '2.8.1'
 gem 'bson_ext', '1.9.2'
 
-gem 'plek', '1.4.0'
+gem 'plek', '~> 1.10'
 gem 'aws-ses', :require => 'aws/ses'
 gem 'gds-api-adapters', '7.19.0'
 
@@ -26,6 +26,8 @@ else
   gem 'gds-sso', '9.3.0'
 end
 
+gem 'airbrake', '~> 4.1.0'
+
 group :test do
   gem 'database_cleaner', '1.1.1', require: false
   gem 'factory_girl_rails', '4.2.1'
@@ -39,5 +41,4 @@ group :test do
 end
 
 gem 'unicorn'
-gem 'exception_notification', '2.6.1'
 gem 'whenever', '0.8.4', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,9 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
+    airbrake (4.1.0)
+      builder
+      multi_json
     arel (3.0.3)
     aws-ses (0.5.0)
       builder
@@ -53,8 +56,6 @@ GEM
       faraday
       multi_json
     erubis (2.7.0)
-    exception_notification (2.6.1)
-      actionmailer (>= 3.0.4)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.2.1)
@@ -134,7 +135,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    plek (1.4.0)
+    plek (1.10.0)
     polyglot (0.3.5)
     rack (1.4.5)
     rack-accept (0.4.5)
@@ -212,11 +213,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (~> 4.1.0)
   aws-ses
   bson_ext (= 1.9.2)
   database_cleaner (= 1.1.1)
   elasticsearch (= 0.4.1)
-  exception_notification (= 2.6.1)
   factory_girl_rails (= 4.2.1)
   gds-api-adapters (= 7.19.0)
   gds-sso (= 9.3.0)
@@ -227,7 +228,7 @@ DEPENDENCIES
   mocha (= 0.14.0)
   mongoid (= 2.8.1)
   mongoid_rails_migrations (= 1.0.1)
-  plek (= 1.4.0)
+  plek (~> 1.10)
   rails (= 3.2.17)
   shoulda (= 3.5.0)
   shoulda-matchers (= 2.7.0)

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -158,7 +158,7 @@ class NeedsController < ApplicationController
     GovukNeedApi.indexer.index(Search::IndexableNeed.new(need))
     true
   rescue Search::Indexer::IndexingFailed => e
-    ExceptionNotifier::Notifier.background_exception_notification(e)
+    Airbrake.notify_or_ignore(e)
     false
   end
 

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
+
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
+end

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -320,8 +320,8 @@ class NeedsControllerTest < ActionController::TestCase
           end
 
           should "send out an exception report" do
-            ExceptionNotifier::Notifier
-              .expects(:background_exception_notification)
+            Airbrake
+              .expects(:notify_or_ignore)
               .with(@exception)
             post :create, @need_with_author
           end
@@ -510,8 +510,8 @@ class NeedsControllerTest < ActionController::TestCase
           end
 
           should "send out an exception report" do
-            ExceptionNotifier::Notifier
-              .expects(:background_exception_notification)
+            Airbrake
+              .expects(:notify_or_ignore)
               .with(@exception)
             put :update, @updates_with_author
           end


### PR DESCRIPTION
so we can send errors to errbit.  This includes an initializer to read
the errbit key from the environment.

This relies on https://github.gds/gds/alphagov-deployment/pull/893 and https://github.gds/gds/puppet/pull/2770