### PR TITLE
Populate organisation content_ids when updating.

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,6 +3,7 @@ class Organisation
 
   field :name, type: String
   field :slug, type: String
+  field :content_id, type: String
   field :govuk_status, type: String, default: ""
   field :abbreviation, type: String, default: ""
   field :parent_ids, type: Array, default: []

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -20,6 +20,7 @@ class OrganisationImporter
     parent_ids = related_organisation_slugs(organisation_from_api.parent_organisations)
 
     organisation_atts = {
+      :content_id => organisation_from_api.details.content_id,
       :name => organisation_from_api.title,
       :slug => organisation_from_api.details.slug,
       :abbreviation => organisation_from_api.details.abbreviation,


### PR DESCRIPTION
This is a precursor to updating the import process to use the content_id
as its key when updating so that it can handle organisation slug
changes.