### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'mongoid', '2.8.1'
 gem 'bson_ext', '1.9.2'
 
 gem 'plek', '~> 1.10'
-gem 'gds-api-adapters', '7.19.0'
+gem 'gds-api-adapters', '20.1.1'
 
 gem "mongoid_rails_migrations", "1.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     database_cleaner (1.1.1)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     elasticsearch (0.4.1)
       elasticsearch-api (= 0.4.1)
       elasticsearch-transport (= 0.4.1)
@@ -58,12 +60,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (7.19.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     gds-sso (9.3.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -75,6 +78,8 @@ GEM
       warden-oauth2 (~> 0.0.1)
     hashie (3.2.0)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     journey (1.0.4)
     json (1.8.3)
@@ -112,6 +117,7 @@ GEM
     multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    netrc (0.10.3)
     null_logger (0.0.1)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -161,8 +167,10 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redis (3.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     safe_yaml (0.9.7)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -188,6 +196,9 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.44)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -212,7 +223,7 @@ DEPENDENCIES
   database_cleaner (= 1.1.1)
   elasticsearch (= 0.4.1)
   factory_girl_rails (= 4.2.1)
-  gds-api-adapters (= 7.19.0)
+  gds-api-adapters (= 20.1.1)
   gds-sso (= 9.3.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information