### PR TITLE
Add required fields for GDS-SSO

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,10 @@ class User
   field "version", type: Integer
   field "email",   type: String
   field "permissions", type: Array
+  field "disabled", type: Boolean, default: false
   field "remotely_signed_out", type: Boolean, default: false
   field "organisation_slug", type: String
+  field "organisation_content_id", type: String
 
   def self.find_by_uid(uid)
     where(uid: uid).first


### PR DESCRIPTION
This PR is somewhat speculative - I haven't reproduced and verified that this fixes it yet. Deploying the branch to preview is probably the easiest way.

gds-sso expects this field to be defined. It seems that before the [recent
Mongoid upgrade](https://github.com/alphagov/govuk_need_api/pull/96), this didn't raise an error (perhaps just a warning?) but now it does.

This might be the change that is leading to the error being raised (included in Mongoid 3): 
```
#3888 raise UnknownAttributeError when 'set' is called on non existing field and Mongoid::Attributes::Dynamic is not included in model. (Shweta Kale)

#3889 'set' will allow to set value of non existing field when Mongoid::Attributes::Dynamic is included in model. (Shweta Kale)
``` https://github.com/mongodb/mongoid/blob/master/CHANGELOG.md#resolved-issues-2