### PR TITLE
Ensure `status` can be updated

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -160,6 +160,12 @@ class NeedsController < ApplicationController
       met_when: [],
       organisation_ids: [],
       justifications: [],
+      status: [
+        :description,
+        :additional_comments,
+        :validation_conditions,
+        reasons: [],
+      ],
     )
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/uy1pE8ra

Prior to this change the `status` and associated attributes were not
being permitted by strong parameters. This covers the various
permutations of parameters and `status` attributes.