### PR TITLE
Migration to remove an org created in error

### DIFF
--- a/db/migrate/20160420111627_remove_appointed_person_for_england_and_wales_organisation.rb
+++ b/db/migrate/20160420111627_remove_appointed_person_for_england_and_wales_organisation.rb
@@ -1,0 +1,26 @@
+class RemoveAppointedPersonForEnglandAndWalesOrganisation < Mongoid::Migration
+  def self.up
+    organisation = Organisation.where(_id: 'appointed-person-for-england-and-wales-under-the-proceeds-of-crime-act-2002').first
+    if organisation.present?
+      Need.where(organisation_ids: organisation.id).each do |need|
+        print "#{need.need_id}: "
+        need.organisation_ids = (need.organisation_ids - [organisation.id])
+
+        if need.save
+          print "Removed"
+        else
+          print "Error\n"
+          print need.errors.full_messages.join("\n\t\t")
+        end
+        print "\n"
+        GovukNeedApi.indexer.index(Search::IndexableNeed.new(need))
+      end
+
+      organisation.destroy
+    end
+  end
+
+  def self.down
+    # This org was created in error, there's no need for a down to re-instate it
+  end
+end


### PR DESCRIPTION
This org was created in error and we are removing it.  The traffic is very low so we're not issuing a 410, just removing it (it should never have existed so a 404 is really what we want).

This is PR 3 of 5 for removing this org.

For more detail: https://trello.com/c/jbImjyLP/359-delete-an-org-page-5
