### PR TITLE
Environment variables for Redis and Elasticsearch

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,3 +1,5 @@
 # NOTE: the `search.rb` initializer relies on this file being loaded first,
 # which it currently manages because it comes first in the alphabet.
-GovukNeedApi.search_client = Elasticsearch::Client.new(host: "localhost:9200")
+GovukNeedApi.search_client = Elasticsearch::Client.new(
+  hosts: ENV['ELASTICSEARCH_HOSTS'].split(',')
+)

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,4 +1,4 @@
-host: 127.0.0.1
+host: <%= ENV['REDIS_HOST'] %>
 port: 6379
 namespace: 'need-api'
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -18,5 +18,8 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
     app test lib config
 fi
 
+export ELASTICSEARCH_HOSTS="localhost:9200"
+export REDIS_HOST="127.0.0.1"
+
 bundle exec rake db:mongoid:drop
 bundle exec rake test

--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -24,7 +24,7 @@ class DistributedLock
 private
   def redis
     @_redis ||= begin
-      redis_config = YAML.load_file(File.join(Rails.root, "config", "redis.yml"))
+      redis_config = Rails.application.config_for(:redis)
       Redis.new(redis_config.symbolize_keys)
     end
   end


### PR DESCRIPTION
Env vars are the better way to configure this application.

The Elasticsearch initializer can take an array of hostnames even if there's only one.