### PR TITLE
Get oauth_root_url from Plek

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
-  config.user_model   = 'User'
-  config.oauth_id     = ENV['OAUTH_ID']
-  config.oauth_secret = ENV['OAUTH_SECRET']
-  config.oauth_root_url = "http://localhost:3001"
+  config.user_model   = "User"
+  config.oauth_id     = ENV["OAUTH_ID"]
+  config.oauth_secret = ENV["OAUTH_SECRET"]
+  config.oauth_root_url = Plek.find("signon")
 end


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Gets the `oauth_root_url` from Plek, this file will no longer be overwritten by alphagov-deployment.