### PR TITLE
Fix redis config to suit Rails::Application#config_for

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,4 +1,12 @@
-host: <%= ENV['REDIS_HOST'] %>
-port: 6379
-namespace: 'need-api'
-
+development:
+  host: 127.0.0.1
+  port: 6379
+  namespace: 'need-api'
+test:
+  host: 127.0.0.1
+  port: 6379
+  namespace: 'need-api'
+production:
+  host: <%= ENV['REDIS_HOST'] %>
+  port: 6379 
+  namespace: 'need-api'


### PR DESCRIPTION
[Rails::Application#config_for](https://github.com/alphagov/govuk_need_api/commit/baaf27901f5d3e476a72a98a9250980e375e10a8#diff-708bd85c88196ff6f86f209f1b2ce89cR27) expects the YAML config file to split
configurations by environment, so do that.