### PR TITLE
Make every need have a content ID

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -5,6 +5,7 @@ class Need
 
   field :_id, type: String, default: -> { need_id }
   field :need_id, type: Integer
+  field :content_id, type: String, default: -> { SecureRandom.uuid }
   field :role, type: String
   field :goal, type: String
   field :benefit, type: String

--- a/db/migrate/20161205144737_add_content_ids_to_needs.rb
+++ b/db/migrate/20161205144737_add_content_ids_to_needs.rb
@@ -1,0 +1,11 @@
+class AddContentIdsToNeeds < Mongoid::Migration
+  def self.up
+    Need.all.each do |n|
+      unless n.content_id.present?
+        n.content_id = SecureRandom.uuid
+        puts "Set content_id #{n.content_id} for #{n.id}."
+        n.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
- This is one of the steps in making Needs appear in the Publishing API.
- For existing needs, there's a migration to give them randomly
  generated content IDs, and for newly created needs, a
  `SecureRandom.uuid` content ID will be assigned to them by default.

Paired with @binaryberry.

Trello: https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api