### PR TITLE
Add sensible default for Elasticsearch hosts

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,5 @@
 # NOTE: the `search.rb` initializer relies on this file being loaded first,
 # which it currently manages because it comes first in the alphabet.
 GovukNeedApi.search_client = Elasticsearch::Client.new(
-  hosts: ENV['ELASTICSEARCH_HOSTS'].split(',')
+  hosts: (ENV['ELASTICSEARCH_HOSTS'] || "http://localhost:9200").split(',')
 )


### PR DESCRIPTION
Just so that this doesn't have to be set by most people locally.