### PR TITLE
Add an API endpoint to find the content_id for the specified need_id

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -35,6 +35,10 @@ class NeedsController < ApplicationController
            status: :ok
   end
 
+  def content_id
+    render json: @need.content_id
+  end
+
   def create
     # Explicitly deny need IDs in create requests
     # This is a controller-level concern, rather than a model-level one, as we

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   resources :needs, except: [:new, :edit]
   resources :notes, only: [:create]
 
+  get '/needs/:id/content_id', to: 'needs#content_id'
+
   put '/needs/:id/closed', to: 'needs#closed'
   delete '/needs/:id/closed', to: 'needs#reopen'
 

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
   end
 
   factory :need do
+    content_id SecureRandom.uuid
     sequence(:role) {|n| "user #{n}" }
     goal "pay my council tax"
     benefit "I don't receive a fine"

--- a/test/functional/needs_controller_test.rb
+++ b/test/functional/needs_controller_test.rb
@@ -217,6 +217,15 @@ class NeedsControllerTest < ActionController::TestCase
     end
   end
 
+  context "GET content_id" do
+    should "show the content_id for a need" do
+      @need = create(:need)
+      get 'content_id', id: @need
+
+      assert_equal @need.content_id, response.body
+    end
+  end
+
   context "POST create" do
     context "given a valid need" do
       setup do


### PR DESCRIPTION
- This is to facilitate the transition from need_ids to content_ids, so
  that we can match them up in other apps.

(cc @cbaines)