### PR TITLE
Publish needs to Publishing-API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,12 @@ gem 'rails', '4.2.5.1'
 gem 'mongoid', '4.0.2'
 
 gem 'plek', '~> 1.11'
-gem 'gds-api-adapters', '26.2.0'
+
+if ENV['API_DEV']
+  gem 'gds-api-adapters', path: '../gds-api-adapters'
+else
+  gem 'gds-api-adapters', '26.2.0'
+end
 
 gem 'mongoid_rails_migrations', '1.1.0'
 

--- a/db/migrate/20161213112441_update_organisation_slug.rb
+++ b/db/migrate/20161213112441_update_organisation_slug.rb
@@ -1,0 +1,31 @@
+class UpdateOrganisationSlug < Mongoid::Migration
+  def self.up
+    organisation = Organisation.find_by(slug: "government-actuary-s-department")
+    organisation.update_attributes({
+      _id: "government-actuarys-department",
+      slug: "government-actuarys-department"
+    })
+    needs_to_correct = Need.where(organisation_ids: ["government-actuary-s-department"])
+    needs_to_correct.each do |n|
+      n.organisation_ids=["government-actuarys-department"]
+      n.save
+    end
+  end
+
+  def self.down
+    organisation =
+      Organisation.find_by(slug: "government-actuary-s-department") ||
+      Organisation.find_by(slug: "government-actuarys-department")
+    organisation.update_attributes({
+      _id: "government-actuary-s-department",
+      slug: "government-actuary-s-department"
+    })
+    needs_to_correct =
+    Need.where( organisation_ids: ["government-actuary-s-department"] ) ||
+    Need.where( organisation_ids: ["government-actuarys-department"] )
+    needs_to_correct.each do |n|
+      n.organisation_ids=["government-actuarys-department"]
+      n.save
+    end
+  end
+end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -18,6 +18,8 @@ private
   def export(need)
     snapshots = need.revisions.map{ |nr| present_need_revision(nr)}
     @api_client.import(need.content_id, snapshots)
+    links = present_links(need)
+    @api_client.patch_links(need.content_id, links: links)
   end
 
   def present_need_revision(need_revision)
@@ -40,6 +42,7 @@ private
     }
   end
 
+
   def present_details(snapshot)
     details = {}
     snapshot.each do |key, value|
@@ -54,6 +57,17 @@ private
     details
   end
 
+  def present_links(need)
+    links = {}
+    need.attributes.each do |key, value|
+      next unless is_a_link?(key) && value.present?
+      if key == "organisation_ids"
+        links["organisations"]= need.organisations.map(&:content_id)
+      end
+    end
+    links
+  end
+
   def is_a_link?(key)
     key == "organisation_ids"
   end
@@ -61,5 +75,4 @@ private
   def should_not_be_in_details(key,value)
     is_a_link?(key) || value == nil
   end
-
 end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -63,13 +63,16 @@ private
       next unless is_a_link?(key) && value.present?
       if key == "organisation_ids"
         links["organisations"] = need.organisations.map(&:content_id)
+      elsif key == "duplicate_of"
+        links["related_items"] = related_needs(need).map(&:content_id)
       end
     end
     links
   end
 
   def is_a_link?(key)
-    key == "organisation_ids"
+    key == "organisation_ids" ||
+      key == "duplicate_of"
   end
 
   def should_not_be_in_details(key, value)
@@ -78,5 +81,9 @@ private
 
   def slug(need_revision)
     need_revision.need.benefit.parameterize
+  end
+
+  def related_needs(need)
+    Need.where(need_id: need.duplicate_of)
   end
 end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -3,7 +3,6 @@ require 'gds_api/publishing_api_v2'
 require 'csv'
 
 class NeedsExporter
-
   def initialize
     @needs = Need.all
     @api_client = GdsApi::PublishingApiV2.new(Plek.find('publishing-api'))
@@ -16,7 +15,7 @@ class NeedsExporter
 private
 
   def export(need)
-    snapshots = need.revisions.map{ |nr| present_need_revision(nr)}
+    snapshots = need.revisions.map { |nr| present_need_revision(nr)}
     @api_client.import(need.content_id, snapshots)
     links = present_links(need)
     @api_client.patch_links(need.content_id, links: links)
@@ -45,12 +44,14 @@ private
   def present_details(snapshot)
     details = {}
     snapshot.each do |key, value|
-      if should_not_be_in_details(key,value)
+      if should_not_be_in_details(key, value)
         next
       elsif key == "status"
-        details["status"]= value["description"]
+        details["status"] = value["description"]
+      elsif key.start_with?("yearly")
+        details["#{key}"] = value.to_s
       else
-        details["#{key}"]=value
+        details["#{key}"] = value
       end
     end
     details
@@ -61,7 +62,7 @@ private
     need.attributes.each do |key, value|
       next unless is_a_link?(key) && value.present?
       if key == "organisation_ids"
-        links["organisations"]= need.organisations.map(&:content_id)
+        links["organisations"] = need.organisations.map(&:content_id)
       end
     end
     links
@@ -71,7 +72,7 @@ private
     key == "organisation_ids"
   end
 
-  def should_not_be_in_details(key,value)
+  def should_not_be_in_details(key, value)
     is_a_link?(key) || value == nil
   end
 

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -1,0 +1,42 @@
+#encoding: utf-8
+require 'gds_api/publishing_api_v2'
+require 'csv'
+
+class NeedsExporter
+
+  def initialize
+    @needs = Need.all
+    @api_client = GdsApi::PublishingApiV2.new(Plek.find('publishing-api'))
+  end
+
+  def run
+    export(@needs[0])
+  end
+
+private
+
+  def export(need)
+    snapshots = need.revisions.map{ |nr| present_need_revision(nr)}
+    @api_client.import(need.content_id, snapshots)
+  end
+
+  def present_need_revision(need_revision)
+    {
+      action: "Publish",
+      payload: {
+                title: need_revision_title(need_revision),
+                publishing_app: "Need-API",
+                schema_name: "need",
+                document_type: "need",
+                rendering_app: "info-frontend",
+                base_path: "/a_path",
+                routes: [{
+                  path: "/a_path",
+                  type: "exact"
+                }],
+                details: need_revision.snapshot
+               }
+    }
+  end
+
+end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -29,14 +29,37 @@ private
                 schema_name: "need",
                 document_type: "need",
                 rendering_app: "info-frontend",
+                locale: "en",
                 base_path: "/a_path",
                 routes: [{
                   path: "/a_path",
                   type: "exact"
                 }],
-                details: need_revision.snapshot
+                details: present_details(need_revision.snapshot)
                }
     }
+  end
+
+  def present_details(snapshot)
+    details = {}
+    snapshot.each do |key, value|
+      if should_not_be_in_details(key,value)
+        next
+      elsif key == "status"
+        details["status"]= value["description"]
+      else
+        details["#{key}"]=value
+      end
+    end
+    details
+  end
+
+  def is_a_link?(key)
+    key == "organisation_ids"
+  end
+
+  def should_not_be_in_details(key,value)
+    is_a_link?(key) || value == nil
   end
 
 end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -79,7 +79,10 @@ private
   end
 
   def should_not_be_in_details(key, value)
-    is_a_link?(key) || value == nil
+    is_a_link?(key) ||
+      value == nil ||
+      key == "content_id" ||
+      deprecated_fields.include?(key)
   end
 
   def slug(need_revision)
@@ -88,5 +91,9 @@ private
 
   def related_needs(need)
     Need.where(need_id: need.duplicate_of)
+  end
+
+  def deprecated_fields
+    %w{monthly_user_contacts monthly_need_views currently_met in_scope out_of_scope_reason}
   end
 end

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -9,7 +9,10 @@ class NeedsExporter
   end
 
   def run
-    export(@needs[0])
+    @needs.each_with_index do |need, index|
+      p "#{index}/#{@needs.count}"
+      export(need)
+    end
   end
 
 private

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -26,22 +26,21 @@ private
     {
       action: "Publish",
       payload: {
-                title: need_revision_title(need_revision),
+                title: need_revision.snapshot["benefit"],
                 publishing_app: "Need-API",
                 schema_name: "need",
                 document_type: "need",
                 rendering_app: "info-frontend",
                 locale: "en",
-                base_path: "/a_path",
+                base_path: "/needs/#{slug(need_revision)}",
                 routes: [{
-                  path: "/a_path",
+                  path: "/needs/#{slug(need_revision)}",
                   type: "exact"
                 }],
                 details: present_details(need_revision.snapshot)
                }
     }
   end
-
 
   def present_details(snapshot)
     details = {}
@@ -74,5 +73,9 @@ private
 
   def should_not_be_in_details(key,value)
     is_a_link?(key) || value == nil
+  end
+
+  def slug(need_revision)
+    need_revision.need.benefit.parameterize
   end
 end

--- a/lib/tasks/needs.rake
+++ b/lib/tasks/needs.rake
@@ -7,7 +7,7 @@ namespace :needs do
   end
 
   desc "Bulk export needs to the Publishing API"
-  task export: :environment do |_t, args|
+  task export: :environment do |_t, _args|
     NeedsExporter.new.run
   end
 end

--- a/lib/tasks/needs.rake
+++ b/lib/tasks/needs.rake
@@ -5,4 +5,9 @@ namespace :needs do
   task :import, [:path] => :environment do |_t, args|
     NeedsImporter.new(Rails.root.join(args[:path])).run
   end
+
+  desc "Bulk export needs to the Publishing API"
+  task export: :environment do |_t, args|
+    NeedsExporter.new.run
+  end
 end


### PR DESCRIPTION
This adds a rake task to the need-API allowing to publish needs to Publishing-API, including their previous versions. 

For the rake task to work, the following PRs will need to be merged:
- Publishing-API's import endpoint PR: https://github.com/alphagov/publishing-api/pull/622
- govuk-content-schemas's enhanced need schema PR: https://github.com/alphagov/govuk-content-schemas/pull/461
- gds-api-adapters's import endpoint PR: https://github.com/alphagov/gds-api-adapters/pull/630

Decisions:
- treat `organisations` and `duplicate_of` as links in the Publishing-API.  The latter are marked as related links, since they are linking to other needs.
- do not send deprecated fields to the Publishing-API. A few records had fields that are no longer in use in Need-API nor Maslow as they've been replaced by another field, sounded sensible not to add that into the Publishing-API.
- do not send the content-id as part of the payload, as the import endpoint expects it in the url of the request.

[Trello](https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api)