### PR TITLE
Update export task to map to Publishing-API workflow

### DIFF
--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -31,7 +31,7 @@ private
   def present_need_revision(need_revision, slug)
     {
        title: need_revision.snapshot["benefit"],
-       publishing_app: "Need-API",
+       publishing_app: "need-api",
        schema_name: "need",
        document_type: "need",
        rendering_app: "info-frontend",

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -11,8 +11,7 @@ class NeedsExporter
 
   def run
     @needs.each_with_index do |need, index|
-      p "#{index}/#{@needs.count}"
-      export(need)
+      export(need, index)
     end
   end
 
@@ -24,6 +23,8 @@ private
     @api_client.import(need.content_id, snapshots)
     links = present_links(need)
     @api_client.patch_links(need.content_id, links: links)
+    p "#{index}/#{@needs.count}"
+    p "exported #{slug}"
   end
 
   def present_need_revision(need_revision, slug)

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -170,7 +170,12 @@ private
   end
 
   def map_to_publishing_api_state(need_revision)
-   if is_proposed?(need_revision) || is_invalid?(need_revision)
+    if need_revision.duplicate_of.present? && status == "proposed"
+      {
+        name: "unpublished",
+        type: "withdrawal"
+      }
+    elsif is_proposed?(need_revision) || is_invalid?(need_revision)
       "draft"
     elsif is_valid?(need_revision)
       return "superseded" if published_already_in_list?(need_revision.need.revisions)

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -37,7 +37,7 @@ private
        rendering_app: "info-frontend",
        locale: "en",
        base_path: "/needs/#{slug}",
-       state: map_to_publishing_api_state(need_revision),
+       state: map_to_publishing_api_state(need_revision, slug),
        routes: [{
          path: "/needs/#{slug}",
          type: "exact"
@@ -169,13 +169,14 @@ private
     need_revision.snapshot["status"] && need_revision.snapshot["status"]["description"]
   end
 
-  def map_to_publishing_api_state(need_revision)
-    if need_revision.duplicate_of.present? && status == "proposed"
+  def map_to_publishing_api_state(need_revision, slug)
+    if need_revision.snapshot["duplicate_of"].present? && is_valid?(need_revision)
       {
         name: "unpublished",
-        type: "withdrawal"
+        type: "withdrawal",
+        explanation: "This need is a duplicate_of the need [#{need_revision.need.benefit}](/needs/#{slug})"
       }
-    elsif is_proposed?(need_revision) || is_invalid?(need_revision)
+    elsif is_proposed?(need_revision) || is_not_valid?(need_revision)
       "draft"
     elsif is_valid?(need_revision)
       return "superseded" if published_already_in_list?(need_revision.need.revisions)

--- a/lib/needs_exporter.rb
+++ b/lib/needs_exporter.rb
@@ -26,21 +26,19 @@ private
 
   def present_need_revision(need_revision)
     {
-      action: "Publish",
-      payload: {
-                title: need_revision.snapshot["benefit"],
-                publishing_app: "Need-API",
-                schema_name: "need",
-                document_type: "need",
-                rendering_app: "info-frontend",
-                locale: "en",
-                base_path: "/needs/#{slug(need_revision)}",
-                routes: [{
-                  path: "/needs/#{slug(need_revision)}",
-                  type: "exact"
-                }],
-                details: present_details(need_revision.snapshot)
-               }
+       title: need_revision.snapshot["benefit"],
+       publishing_app: "Need-API",
+       schema_name: "need",
+       document_type: "need",
+       rendering_app: "info-frontend",
+       locale: "en",
+       base_path: "/needs/#{slug(need_revision)}",
+       state: state(need_revision),
+       routes: [{
+         path: "/needs/#{slug(need_revision)}",
+         type: "exact"
+       }],
+       details: present_details(need_revision.snapshot)
     }
   end
 
@@ -95,5 +93,24 @@ private
 
   def deprecated_fields
     %w{monthly_user_contacts monthly_need_views currently_met in_scope out_of_scope_reason}
+  end
+
+  def state(need_revision)
+    if is_latest?(need_revision)
+      need_revision.need.status
+    elsif includes_snapshot?(need_revision)
+      need_revision.snapshot["status"]["description"]
+    else
+      "superseded"
+    end
+  end
+
+  def is_latest?(need_revision)
+    all_revisions = need_revision.need.revisions
+    all_revisions[0] == need_revision
+  end
+
+  def includes_snapshot?(need_revision)
+    need_revision.snapshot["status"] && need_revision.snapshot["status"]["description"]
   end
 end


### PR DESCRIPTION
The Publishing-API import endpoint now requires a different payload, providing a state for each content-item being imported, and setting the action at the content level instead of the content-item level.
This change sends:
- needs that have a "proposed" or "not valid" status as drafts
- needs that have a "valid" or "valid with conditions" as published if they are the latest version, or superseded if they aren't. If they are a duplicate of another need, they're sent as withdrawn.

[Trello](https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api)