### PR TITLE
Really add content IDs to needs with a migration

### DIFF
--- a/db/migrate/20170110164453_really_add_content_ids_to_needs.rb
+++ b/db/migrate/20170110164453_really_add_content_ids_to_needs.rb
@@ -1,0 +1,11 @@
+class ReallyAddContentIdsToNeeds < Mongoid::Migration
+  def self.up
+    Need.all.each do |n|
+      unless n.content_id.blank?
+        n.content_id = SecureRandom.uuid
+        puts "Set content_id #{n.content_id} for #{n.id}."
+        n.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The first version of this was using `.present?` instead of `.blank?`.
  It worked in testing but I've spent the last however long scratching
  my head as to why nothing was showing up for the next stage of this
  process, only to realise that it never actually added content_ids to
  needs for a lot of them. 😳 