### PR TITLE
The needs are given Content IDs by default - just use that to save them

### DIFF
--- a/db/migrate/20170110164453_really_add_content_ids_to_needs.rb
+++ b/db/migrate/20170110164453_really_add_content_ids_to_needs.rb
@@ -1,11 +1,7 @@
 class ReallyAddContentIdsToNeeds < Mongoid::Migration
   def self.up
     Need.all.each do |n|
-      unless n.content_id.blank?
-        n.content_id = SecureRandom.uuid
-        puts "Set content_id #{n.content_id} for #{n.id}."
-        n.save
-      end
+      n.save
     end
   end
 end


### PR DESCRIPTION
- We were somewhat overengineering this (and the `unless` made it a double negative which didn't work the way we wanted it to)!