### PR TITLE
Upgrade gds-api-adapters to 39.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.11'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', git: 'https://github.com/alphagov/gds-api-adapters.git', branch: 'add-import-endpoint-adapter'
+  gem 'gds-api-adapters', '39.2.0'
 end
 
 gem 'mongoid_rails_migrations', '1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/gds-api-adapters.git
-  revision: 6b859b45f5e5186683803031ad8aa3801c4f6083
-  branch: add-import-endpoint-adapter
-  specs:
-    gds-api-adapters (39.1.0)
-      link_header
-      lrucache (~> 0.1.1)
-      null_logger
-      plek (>= 1.9.0)
-      rack-cache
-      rest-client (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,6 +71,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    gds-api-adapters (39.2.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
     gds-sso (11.2.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -264,7 +258,7 @@ DEPENDENCIES
   database_cleaner (= 1.5.1)
   elasticsearch (= 1.0.14)
   factory_girl_rails (= 4.5.0)
-  gds-api-adapters!
+  gds-api-adapters (= 39.2.0)
   gds-sso (= 11.2.0)
   govuk-lint (~> 0.4)
   kaminari (= 0.16.3)


### PR DESCRIPTION
The new version has been released so we do not need to point to the branch
anymore.

https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api